### PR TITLE
Bug fixes

### DIFF
--- a/developer_notes.md
+++ b/developer_notes.md
@@ -134,6 +134,10 @@ Reference obfuscate process at https://docs.flutter.dev/deployment/obfuscate
 6. Upload symbols file to play store:
    Files to upload: https://stackoverflow.com/questions/62568757/playstore-error-app-bundle-contains-native-code-and-youve-not-uploaded-debug/68778908#68778908
    How to upload: https://docs.unity3d.com/ru/2021.1/Manual/android-symbols.html#:~:text=To%20do%20this%2C%20click%20the,zip).&text=After%20you%20upload%20the%20symbols,information%20on%20what%20went%20wrong.
-7. After testing upload or move test version on play store to production
+   If get upload error about the zip file having Mac symbols
+      https://stackoverflow.com/questions/76621039/flutter-the-native-debug-symbols-contain-an-invalid-directory-macosx-when-up
+
+   zip -d Archive.zip "__MACOSX*" 
+
 
 

--- a/lib/soaring/app/constants.dart
+++ b/lib/soaring/app/constants.dart
@@ -244,8 +244,12 @@ class TaskLiterals {
   static const String ADD_TURNPOINTS = "Add Turnpoints";
   static const String ADD_TASK = "ADD";
   static const String SAVE_TASK = "SAVE";
-  static var LEAVE_BLANK_FOR_DEFAULT_NAME =
+  static const String LEAVE_BLANK_FOR_DEFAULT_NAME =
       "Leave blank for default name when saved";
+  static const String INVALID_TASK = "Invalid Task";
+  static const String INVALID_TASK_CAN_NOT_BE_SAVED = "The invalid task can not be saved.";
+  static const String UPDATE_TASK = "Update Task";
+  static const String CANCEL_TASK = "Cancel Task";
 }
 
 class TurnpointMenu {

--- a/lib/soaring/forecast/bloc/rasp_data_bloc.dart
+++ b/lib/soaring/forecast/bloc/rasp_data_bloc.dart
@@ -130,6 +130,7 @@ class RaspDataBloc extends Bloc<RaspDataEvent, RaspDataState> {
   Future<void> _processSwitchedRegion(
       SwitchedRegionEvent event, Emitter<RaspDataState> emit) async {
     repository.setCurrentTaskId(-1);
+    emit(ShowEstimatedFlightButton(false));
   }
 
   Future<void> _listTypesOfForecasts(_, Emitter<RaspDataState> emit) async {

--- a/lib/soaring/glider/bloc/glider_cubit.dart
+++ b/lib/soaring/glider/bloc/glider_cubit.dart
@@ -54,6 +54,8 @@ class GliderCubit extends Cubit<GliderCubitState> {
     String selectedGlider = await _repository.getLastSelectedGliderName();
     emit(GliderListState(
         gliders, selectedGlider));
+    DisplayUnits displayUnits = await _repository.getPolarDisplayUnits();
+    emit (PolarUnitsState(displayUnits));
 
     if (selectedGlider.isNotEmpty) {
       await getGliderPolar(selectedGlider);
@@ -61,9 +63,8 @@ class GliderCubit extends Cubit<GliderCubitState> {
 
     bool showPolarHelp = await _repository.getShowPolarHelp();
     if (showPolarHelp){
-      emit(ShowPolarHelpState(showPolarHelp));
+      emit(ShowPolarHelpState());
     }
-
     _indicateWorking(false);
   }
 
@@ -71,7 +72,7 @@ class GliderCubit extends Cubit<GliderCubitState> {
     _indicateWorking(true);
 
     _displayXCSoarValues = await _repository.getDisplayXCSoarValues();
-    _displayUnits = await _repository.getDisplayUnits();
+    _displayUnits = await _repository.getPolarDisplayUnits();
     _assignDisplayUnitLabels(_displayUnits);
     var gliderRecord =
         await _repository.getDefaultAndCustomGliderDetails(gliderName);
@@ -92,7 +93,7 @@ class GliderCubit extends Cubit<GliderCubitState> {
     _indicateWorking(true);
     if (_displayUnits == newDisplayUnits) return;
     _displayUnits = newDisplayUnits;
-    await _repository.saveDisplayUnits(newDisplayUnits);
+    await _repository.savePolarDisplayUnits(newDisplayUnits);
     _assignDisplayUnitLabels(newDisplayUnits);
     _convertGliderInfoToPreferredUnits();
     _emitGlidersInfo();
@@ -456,8 +457,8 @@ class GliderCubit extends Cubit<GliderCubitState> {
   }
 
   Future<void> showPolarHelp() async {
-    var showPolarHelp = await _repository.getShowPolarHelp();
-    emit(ShowPolarHelpState(showPolarHelp));
+    await _repository.saveShowPolarHelp(true);
+    emit(ShowPolarHelpState());
   }
 
   Future<void> saveCustomGliderDetails() async {

--- a/lib/soaring/glider/bloc/glider_cubit.dart
+++ b/lib/soaring/glider/bloc/glider_cubit.dart
@@ -61,8 +61,8 @@ class GliderCubit extends Cubit<GliderCubitState> {
       await getGliderPolar(selectedGlider);
     }
 
-    bool showPolarHelp = await _repository.getShowPolarHelp();
-    if (showPolarHelp){
+    bool doNotshowPolarHelp = await _repository.getDoNotShowPolarHelp();
+    if (!doNotshowPolarHelp){
       emit(ShowPolarHelpState());
     }
     _indicateWorking(false);
@@ -453,11 +453,11 @@ class GliderCubit extends Cubit<GliderCubitState> {
   }
 
   displayPolarHelp(bool showPolarHelp) async {
-    await _repository.saveShowPolarHelp(showPolarHelp);
+    await _repository.saveDoNotShowPolarHelp(showPolarHelp);
   }
 
   Future<void> showPolarHelp() async {
-    await _repository.saveShowPolarHelp(true);
+    await _repository.saveDoNotShowPolarHelp(true);
     emit(ShowPolarHelpState());
   }
 

--- a/lib/soaring/glider/bloc/glider_state.dart
+++ b/lib/soaring/glider/bloc/glider_state.dart
@@ -57,9 +57,11 @@ class CalcEstimatedFlightState extends GliderCubitState {
 
 class DisplayEstimatedFlightText extends GliderCubitState {}
 
-class ShowPolarHelpState extends GliderCubitState {
-  final bool showPolarHelp;
+class ShowPolarHelpState extends GliderCubitState {}
 
-  ShowPolarHelpState(this.showPolarHelp);
+class PolarUnitsState extends GliderCubitState{
+  DisplayUnits displayUnits;
+
+  PolarUnitsState(this.displayUnits);
 }
 

--- a/lib/soaring/glider/ui/glider_polar_list.dart
+++ b/lib/soaring/glider/ui/glider_polar_list.dart
@@ -99,6 +99,7 @@ class _GliderPolarListScreenState extends State<GliderPolarListScreen> {
   static const String HELP = "HELP";
 
   bool _displayXCSoarValues = false;
+  bool _doNotShowPolarHelp = false;
 
   // @override
   // FutureOr<void> afterFirstLayout(BuildContext context) async {
@@ -309,15 +310,14 @@ class _GliderPolarListScreenState extends State<GliderPolarListScreen> {
             return CheckboxListTile(
               title: Text("Do not display again. (Can display via HELP)"),
               controlAffinity: ListTileControlAffinity.leading,
-              value: false, // unchecked
+              value: _doNotShowPolarHelp,
               onChanged: (newValue) async {
-                if (newValue != null) {
-                  await _getGliderCubit().displayPolarHelp(!newValue);
-                  setState(() {
-                    // Seems like flutter wants async task out of setstate
-                    // if checked then DO NOT display experimental text, hence save as false
-                  });
-                }
+                _doNotShowPolarHelp = newValue != null ? newValue : false;
+                await _getGliderCubit().displayPolarHelp(_doNotShowPolarHelp);
+                setState(() {
+                  // Seems like flutter wants async task out of setstate
+                  // if checked then DO NOT display experimental text, hence save as false
+                });
               },
             );
           })

--- a/lib/soaring/glider/ui/glider_polar_list.dart
+++ b/lib/soaring/glider/ui/glider_polar_list.dart
@@ -1212,6 +1212,12 @@ class _GliderPolarListScreenState extends State<GliderPolarListScreen> {
   Widget _getGliderStatesHandler() {
     return BlocListener<GliderCubit, GliderCubitState>(
       listener: (context, state) {
+        if (state is GliderListState) {
+          // this is to enable on 'OK' button
+          if (state.selectedGliderName.isNotEmpty )
+            setState(() {
+            });
+        }
         if (state is CalcEstimatedFlightState) {
           Navigator.pop(context, state.glider);
         }

--- a/lib/soaring/glider/ui/glider_polar_list.dart
+++ b/lib/soaring/glider/ui/glider_polar_list.dart
@@ -28,7 +28,7 @@ class _GliderPolarListScreenState extends State<GliderPolarListScreen> {
   List<String> gliders = [];
   late Glider _defaultGliderLocalUnits;
   late Glider? _customGliderLocalUnits = null;
-  late DisplayUnits _displayUnits;
+  late DisplayUnits _displayUnits = DisplayUnits.Imperial_kts;
   String _velocityUnits = "";
   String _sinkRateUnits = "";
   String _massUnits = "";
@@ -61,13 +61,12 @@ class _GliderPolarListScreenState extends State<GliderPolarListScreen> {
   static const String _POLAR_HELP = "HELP";
 
   static const String _GLIDER_POLAR_HELP =
-      "The values displayed on the glider polar screen are initially based and calculated from XCSOAR glider data."
+      "The values displayed on the glider polar screen are based on XCSOAR glider data."
       "\n\nHighlighted values under the 'Your Glider' column can be updated. Tap on the particular cell to update the value."
-      "\n\nAn initial min sink value is calculated based on speed to fly polar values and is likely quite inaccurate."
-      "\n\nConsult your glider POH or other sources to enter better min sink rate and speed values based on your all up glider mass."
+      "\n\nConsult your glider POH or other sources to enter min sink rate and speed values based on your all up glider mass."
       " Also enter your favorite thermaling bank angle."
       "\n\n\The glider mass, sink rate, and Vx/Wx polar values on this screen are "
-      "used to determine your gliders estimated climb rate in a thermal and wind adjusted speed to fly. These values are in turn used to calculate an estimated task time for each leg of your task. \n"
+      "used to determine your gliders estimated climb rate in a thermal and speed to fly. These values are in turn used to calculate an estimated task time for each leg of your task. \n"
       "\nOnly change Vx/Wx values if you have either measured them in your glider or feel you have a better source than XCSoar data."
       "Toggle between metric and American units or reset your glider values back to "
       "the XCSOAR values using the top right menu dropdown";
@@ -100,7 +99,6 @@ class _GliderPolarListScreenState extends State<GliderPolarListScreen> {
   static const String HELP = "HELP";
 
   bool _displayXCSoarValues = false;
-  bool _showPolarHelp = false;
 
   // @override
   // FutureOr<void> afterFirstLayout(BuildContext context) async {
@@ -158,11 +156,16 @@ class _GliderPolarListScreenState extends State<GliderPolarListScreen> {
                   backgroundColor: Theme.of(context).colorScheme.primary,
                 ),
                 child: Text(StandardLiterals.OK),
-                onPressed:  (_selectedGlider == null) ?  null : () async {
-                  await _getGliderCubit().saveCustomGliderDetails();
-                  Navigator.pop(context,
-                      _customGliderLocalUnits != null ? _customGliderLocalUnits!.glider : "");
-                },
+                onPressed: (_selectedGlider == null)
+                    ? null
+                    : () async {
+                        await _getGliderCubit().saveCustomGliderDetails();
+                        Navigator.pop(
+                            context,
+                            _customGliderLocalUnits != null
+                                ? _customGliderLocalUnits!.glider
+                                : "");
+                      },
               ),
             ),
           ),
@@ -203,7 +206,6 @@ class _GliderPolarListScreenState extends State<GliderPolarListScreen> {
           child: const Text(HELP, style: TextStyle(color: Colors.white)),
           onPressed: () {
             _getGliderCubit().showPolarHelp();
-
           }),
       PopupMenuButton<String>(
           onSelected: _handleClick,
@@ -283,19 +285,18 @@ class _GliderPolarListScreenState extends State<GliderPolarListScreen> {
     Navigator.pop(context);
   }
 
-  void _displayPolarHelp(bool showPolarHelp) async {
+  void _displayPolarHelp() async {
     CommonWidgets.showTextAndCheckboxDialogBuilder(
         context: context,
         title: GLIDER_POLAR,
-        child: _getPolarHelpTextWidget(showPolarHelp),
+        child: _getPolarHelpTextWidget(),
         button1Text: StandardLiterals.OK,
         button1Function: (() {
           Navigator.pop(context);
         }));
   }
 
-  Widget _getPolarHelpTextWidget(bool showPolarHelp) {
-    _showPolarHelp = showPolarHelp;
+  Widget _getPolarHelpTextWidget() {
     return SingleChildScrollView(
       child: Column(
         children: [
@@ -308,14 +309,15 @@ class _GliderPolarListScreenState extends State<GliderPolarListScreen> {
             return CheckboxListTile(
               title: Text("Do not display again. (Can display via HELP)"),
               controlAffinity: ListTileControlAffinity.leading,
-              value: !_showPolarHelp,
+              value: false, // unchecked
               onChanged: (newValue) async {
-                _showPolarHelp = newValue != null ? !newValue : true;
-                await _getGliderCubit().displayPolarHelp(_showPolarHelp);
-                setState(() {
-                  // Seems like flutter wants async task out of setstate
-                  // if checked then DO NOT display experimental text, hence save as false
-                });
+                if (newValue != null) {
+                  await _getGliderCubit().displayPolarHelp(!newValue);
+                  setState(() {
+                    // Seems like flutter wants async task out of setstate
+                    // if checked then DO NOT display experimental text, hence save as false
+                  });
+                }
               },
             );
           })
@@ -1214,7 +1216,10 @@ class _GliderPolarListScreenState extends State<GliderPolarListScreen> {
           Navigator.pop(context, state.glider);
         }
         if (state is ShowPolarHelpState) {
-          _displayPolarHelp(state.showPolarHelp);
+          _displayPolarHelp();
+        }
+        if (state is PolarUnitsState) {
+          _displayUnits = state.displayUnits;
         }
       },
       child: SizedBox.shrink(),

--- a/lib/soaring/glider/ui/glider_polar_list.dart
+++ b/lib/soaring/glider/ui/glider_polar_list.dart
@@ -158,7 +158,7 @@ class _GliderPolarListScreenState extends State<GliderPolarListScreen> {
                   backgroundColor: Theme.of(context).colorScheme.primary,
                 ),
                 child: Text(StandardLiterals.OK),
-                onPressed: () async {
+                onPressed:  (_selectedGlider == null) ?  null : () async {
                   await _getGliderCubit().saveCustomGliderDetails();
                   Navigator.pop(context,
                       _customGliderLocalUnits != null ? _customGliderLocalUnits!.glider : "");

--- a/lib/soaring/repository/repository.dart
+++ b/lib/soaring/repository/repository.dart
@@ -111,9 +111,10 @@ class Repository {
   static Gliders? _fullGliderList = null;
   static Gliders? _customGliders = null;
 
-  // these values MUST be the same value as that in the settings.json file.
+  // this value MUST be the same value as that in the settings.json file.
   static const String _SHOW_ESTIMATED_FLIGHT_BUTTON =
       "SHOW_ESTIMATED_FLIGHT_BUTTON";
+
   static const String _SHOW_ESTIMATED_FLIGHT_EXPERIMENTAL_TEXT =
       "SHOW_ESTIMATED_FLIGHT_EXPERIMENTAL_TEXT";
   static const String _SHOW_POLAR_HELP = "SHOW_POLAR_HELP";
@@ -1436,7 +1437,7 @@ class Repository {
     return Gliders();
   }
 
-  Future<DisplayUnits> getDisplayUnits() async {
+  Future<DisplayUnits> getPolarDisplayUnits() async {
     String displayUnit = await getGenericString(
         key: _DISPLAY_UNITS,
         defaultValue: DisplayUnits.Imperial_kts.toString());
@@ -1449,7 +1450,7 @@ class Repository {
         DisplayUnits.Imperial_kts;
   }
 
-  Future<DisplayUnits> saveDisplayUnits(DisplayUnits displayUnits) async {
+  Future<DisplayUnits> savePolarDisplayUnits(DisplayUnits displayUnits) async {
     await saveGenericString(
         key: _DISPLAY_UNITS, value: displayUnits.toString());
     return _convertDisplayUnitsStringToEnum(displayUnits.toString());

--- a/lib/soaring/repository/repository.dart
+++ b/lib/soaring/repository/repository.dart
@@ -111,7 +111,7 @@ class Repository {
   static Gliders? _fullGliderList = null;
   static Gliders? _customGliders = null;
 
-  // this value must be the same value as that in the settings.json file.
+  // these values MUST be the same value as that in the settings.json file.
   static const String _SHOW_ESTIMATED_FLIGHT_BUTTON =
       "SHOW_ESTIMATED_FLIGHT_BUTTON";
   static const String _SHOW_ESTIMATED_FLIGHT_EXPERIMENTAL_TEXT =

--- a/lib/soaring/repository/repository.dart
+++ b/lib/soaring/repository/repository.dart
@@ -1461,7 +1461,7 @@ class Repository {
         key: _EXPERIMENTAL_ESTIMATED_FLIGHT_FLAG, defaultValue: true);
   }
 
-  Future<void> saveDisplayExperimentalEstimatedTaskAlertFlag(bool flag) async {
+  Future<void> saveDisplayExperimentalEstimatedTaskFlag(bool flag) async {
     await saveGenericBool(
         key: _EXPERIMENTAL_ESTIMATED_FLIGHT_FLAG, value: flag);
   }
@@ -1475,11 +1475,11 @@ class Repository {
     return await saveGenericBool(key: _DISPLAY_XCSOAR_VALUES, value: display);
   }
 
-  Future<bool> getShowPolarHelp() async {
+  Future<bool> getDoNotShowPolarHelp() async {
     return await getGenericBool(key: _SHOW_POLAR_HELP, defaultValue: false);
   }
 
-  Future<bool> saveShowPolarHelp(bool display) async {
+  Future<bool> saveDoNotShowPolarHelp(bool display) async {
     return await saveGenericBool(key: _SHOW_POLAR_HELP, value: display);
   }
 

--- a/lib/soaring/task_estimate/cubit/task_estimate_cubit.dart
+++ b/lib/soaring/task_estimate/cubit/task_estimate_cubit.dart
@@ -35,6 +35,7 @@ class TaskEstimateCubit extends Cubit<TaskEstimateState> {
   Future<void> setRegionModelDateParms(
       EstimatedTaskRegionModel estimatedTaskRegionModel) async {
     _indicateWorking(true);
+    //_repository.saveDisplayExperimentalEstimatedTaskAlertFlag(true);
     EstimatedTaskRegionModel info = estimatedTaskRegionModel;
     _regionName = info.regionName;
     _selectedModelName = info.selectedModelName; // nam
@@ -42,9 +43,9 @@ class TaskEstimateCubit extends Cubit<TaskEstimateState> {
     _forecastHours = info.forecastHours;
     _selectedHour = info.forecastHours[info.selectedHourIndex]; // 1300
     var showExperimental =
-    await _repository.getDisplayExperimentalEstimatedTaskAlertFlag();
+      await _repository.getDisplayExperimentalEstimatedTaskAlertFlag();
     if (showExperimental) {
-      emit(DisplayExperimentalHelpText(showExperimental, true));
+      emit(DisplayExperimentalHelpText( true));
     } else {
       doCalc();
     }
@@ -70,14 +71,14 @@ class TaskEstimateCubit extends Cubit<TaskEstimateState> {
     return _gliderPolar;
   }
 
-  Future<bool> checkToDisplayExperimentalText() async {
-    var displayText =
-    await _repository.getShowEstimatedFlightExperimentalText();
-    if (displayText) {
-      emit(DisplayEstimatedFlightText());
-    }
-    return displayText;
-  }
+  // Future<bool> checkToDisplayExperimentalText() async {
+  //   var displayText =
+  //   await _repository.getShowEstimatedFlightExperimentalText();
+  //   if (displayText) {
+  //     emit(DisplayEstimatedFlightText());
+  //   }
+  //   return displayText;
+  // }
 
   // User selected new glider or maybe changed glider polar
   Future<void> calcEstimatedTaskWithNewGlider() async {
@@ -173,10 +174,6 @@ class TaskEstimateCubit extends Cubit<TaskEstimateState> {
     _repository.saveDisplayExperimentalEstimatedTaskAlertFlag(value);
   }
 
-  Future<void> resetExperimentalTextDisplay() async {
-    displayExperimentalText(true);
-    emit(DisplayEstimatedFlightText());
-  }
 
   void updateTimeIndex(int incOrDec) async {
     // print('Current _selectedForecastTimeIndex $_selectedForecastTimeIndex'
@@ -198,9 +195,7 @@ class TaskEstimateCubit extends Cubit<TaskEstimateState> {
 
   // This is used for when user hits help button
   Future<void> showExperimentalTextHelp() async {
-    var showExperimentalText =
-    await _repository.getDisplayExperimentalEstimatedTaskAlertFlag();
-    emit(DisplayExperimentalHelpText(showExperimentalText, false));
+    emit(DisplayExperimentalHelpText(false));
   }
 
 // eliminate duplicate text like (this comes across as 1 long string not by line as shown below

--- a/lib/soaring/task_estimate/cubit/task_estimate_cubit.dart
+++ b/lib/soaring/task_estimate/cubit/task_estimate_cubit.dart
@@ -42,9 +42,9 @@ class TaskEstimateCubit extends Cubit<TaskEstimateState> {
     _selectedForecastDate = info.selectedDate; // selected date  2019-12-19
     _forecastHours = info.forecastHours;
     _selectedHour = info.forecastHours[info.selectedHourIndex]; // 1300
-    var showExperimental =
+    var doNotShowExperimentalText =
       await _repository.getDisplayExperimentalEstimatedTaskAlertFlag();
-    if (showExperimental) {
+    if (!doNotShowExperimentalText) {
       emit(DisplayExperimentalHelpText( true));
     } else {
       doCalc();
@@ -114,7 +114,8 @@ class TaskEstimateCubit extends Cubit<TaskEstimateState> {
       emit(TaskEstimateErrorState(optimizedTaskRoute!.routeSummary!.error!));
       emit(TaskEstimateWorkingState(false));
     } else {
-      _eliminateDuplicateFootingText(optimizedTaskRoute!.routeSummary!.footers);
+      // Updated server code, won't get duplicate lines
+     // _eliminateDuplicateFootingText(optimizedTaskRoute!.routeSummary!.footers);
       emit(TaskEstimateWorkingState(false));
       emit(EstimatedFlightSummaryState(optimizedTaskRoute));
     }
@@ -171,7 +172,7 @@ class TaskEstimateCubit extends Cubit<TaskEstimateState> {
   }
 
   Future<void> displayExperimentalText(bool value) async {
-    _repository.saveDisplayExperimentalEstimatedTaskAlertFlag(value);
+    _repository.saveDisplayExperimentalEstimatedTaskFlag(value);
   }
 
 

--- a/lib/soaring/task_estimate/cubit/task_estimate_state.dart
+++ b/lib/soaring/task_estimate/cubit/task_estimate_state.dart
@@ -24,8 +24,6 @@ class CalcEstimatedFlightState extends TaskEstimateState {
   CalcEstimatedFlightState(this.glider);
 }
 
-class DisplayEstimatedFlightText extends TaskEstimateState {}
-
 class TaskEstimateWorkingState extends TaskEstimateState {
   final bool working;
 
@@ -47,10 +45,9 @@ class CurrentHourState extends TaskEstimateState {
 }
 
 class DisplayExperimentalHelpText extends TaskEstimateState {
-  final bool showExperimentalText;
   final bool calcAfterShow;
 
-  DisplayExperimentalHelpText(this.showExperimentalText, this.calcAfterShow);
+  DisplayExperimentalHelpText(this.calcAfterShow);
 }
 
 class LocalForecastDisplayState extends TaskEstimateState {

--- a/lib/soaring/task_estimate/ui/task_estimate_display.dart
+++ b/lib/soaring/task_estimate/ui/task_estimate_display.dart
@@ -40,7 +40,7 @@ class _TaskEstimateDisplayState extends State<TaskEstimateDisplay> {
       "\n3. Wind direction (Boundary Layer average)"
       "\n\nNote that thermal height is not used so you may be gliding at treetop height!"
       "\n\nTask time, headwind, and related estimates are based on a straight line"
-      " course between turnpoints. (Yeah - how often does that happen.) "
+      " course between turnpoints."
       "\n\nFeedback is most welcome. ";
 
   static const String _SELECT_GLIDER = "Select Glider";
@@ -58,6 +58,7 @@ class _TaskEstimateDisplayState extends State<TaskEstimateDisplay> {
     }
   }
 
+  bool _doNotShowExperimentalDialog = false;
   bool _beginnerMode = true;
 
   @override
@@ -488,13 +489,13 @@ class _TaskEstimateDisplayState extends State<TaskEstimateDisplay> {
   }
 
 // Keeping in case want to display this info again
-  Widget _getTurnpointsTableHeader() {
-    return Center(
-      child: Padding(
-          padding: const EdgeInsets.only(top: 16),
-          child: Text("Task Turnpoints", style: textStyleBoldBlackFontSize18)),
-    );
-  }
+//   Widget _getTurnpointsTableHeader() {
+//     return Center(
+//       child: Padding(
+//           padding: const EdgeInsets.only(top: 16),
+//           child: Text("Task Turnpoints", style: textStyleBoldBlackFontSize18)),
+//     );
+//   }
 
   Widget _getLegTableHeader() {
     return Center(
@@ -522,26 +523,26 @@ class _TaskEstimateDisplayState extends State<TaskEstimateDisplay> {
     );
   }
 
-  Widget _getOptimalFlightCloseButton() {
-    return Align(
-      alignment: Alignment.bottomCenter,
-      child: Padding(
-        padding: const EdgeInsets.all(8.0),
-        child: ElevatedButton(
-          style: ElevatedButton.styleFrom(
-            minimumSize: Size(double.infinity,
-                40), // double.infinity is the width and 30 is the height
-            foregroundColor: Colors.white,
-            backgroundColor: Theme.of(context).colorScheme.primary,
-          ),
-          child: Text("Close"),
-          onPressed: () {
-            _onWillPop();
-          },
-        ),
-      ),
-    );
-  }
+  // Widget _getOptimalFlightCloseButton() {
+  //   return Align(
+  //     alignment: Alignment.bottomCenter,
+  //     child: Padding(
+  //       padding: const EdgeInsets.all(8.0),
+  //       child: ElevatedButton(
+  //         style: ElevatedButton.styleFrom(
+  //           minimumSize: Size(double.infinity,
+  //               40), // double.infinity is the width and 30 is the height
+  //           foregroundColor: Colors.white,
+  //           backgroundColor: Theme.of(context).colorScheme.primary,
+  //         ),
+  //         child: Text("Close"),
+  //         onPressed: () {
+  //           _onWillPop();
+  //         },
+  //       ),
+  //     ),
+  //   );
+  // }
 
   void _displayEstimatedFlightHelp(bool calcAfterShow) async {
     CommonWidgets.showTextAndCheckboxDialogBuilder(
@@ -571,19 +572,15 @@ class _TaskEstimateDisplayState extends State<TaskEstimateDisplay> {
               title: Text(
                   "Do not display again. (But can always display via HELP on Task Estimates screen)"),
               controlAffinity: ListTileControlAffinity.leading,
-              value: false,    // box always unchecked if showing the help
-              // (ie. always show again unless user checks box not to show again
+              value: _doNotShowExperimentalDialog,
               onChanged: (newValue) async {
-                 if (newValue != null) {
-                   // if true then do not show help when coming to this screen
-                   // which perversely means need to send false so don't show help next time
-                   await _getTaskEstimateCubit()
-                       .displayExperimentalText(!newValue);
-                   setState(() {
-                     // Seems like flutter wants async task out of setstate
-                     // if checked then DO NOT display experimental text, hence save as false
-                   });
-                 }
+                _doNotShowExperimentalDialog = newValue != null ? newValue : false;
+                await _getTaskEstimateCubit()
+                    .displayExperimentalText(_doNotShowExperimentalDialog);
+                setState(() {
+                  // Seems like flutter wants async task out of setstate
+                  // if checked then DO NOT display experimental text, hence save as false
+                });
               },
             );
           })

--- a/lib/soaring/task_estimate/ui/task_estimate_display.dart
+++ b/lib/soaring/task_estimate/ui/task_estimate_display.dart
@@ -162,8 +162,10 @@ class _TaskEstimateDisplayState extends State<TaskEstimateDisplay> {
   Future<void> _getGlider() async {
     Object? glider =
         await Navigator.pushNamed(context, GliderPolarListBuilder.routeName);
-    if (glider is String && glider.isNotEmpty) {
+    if (glider != null && glider is String && glider.isNotEmpty) {
       _getTaskEstimateCubit().calcEstimatedTaskWithNewGlider();
+    } else {
+      _onWillPop();
     }
   }
 

--- a/lib/soaring/tasks/bloc/task_bloc.dart
+++ b/lib/soaring/tasks/bloc/task_bloc.dart
@@ -197,6 +197,7 @@ class TaskBloc extends Bloc<TaskEvent, TaskState> {
     emit(TasksTurnpointsLoadedState(
         task: _currentTask, taskTurnpoints: _taskTurnpoints));
     emit(TaskModifiedState());
+    _seeIfValidTask(emit);
   }
 
   void _calculateDistances() {
@@ -316,5 +317,18 @@ class TaskBloc extends Bloc<TaskEvent, TaskState> {
       });
       _currentTask.taskName = defaultTaskName.toString();
     }
+  }
+
+  void _seeIfValidTask(Emitter<TaskState> emit) {
+    bool validTask = false;
+    if (_taskTurnpoints.length < 2 ) {
+        emit(ValidTaskState(validTask, invalidTaskMsg: "Need more than 1 turnpoint"));
+        return;
+      }
+      if   (_taskTurnpoints.length == 2 && _taskTurnpoints[0].code == _taskTurnpoints[1].code){
+        emit(ValidTaskState(validTask, invalidTaskMsg: "Can't have task with only identical start and finish"));
+        return;
+    }
+    (emit(ValidTaskState(true)));
   }
 }

--- a/lib/soaring/tasks/bloc/task_state.dart
+++ b/lib/soaring/tasks/bloc/task_state.dart
@@ -14,28 +14,36 @@ class TasksLoadingState extends TaskState {
 
 class TaskErrorState extends TaskState {
   final String errorMsg;
+
   TaskErrorState(String this.errorMsg);
+
   @override
   List<Object?> get props => [errorMsg];
 }
 
 class TaskShortMessageState extends TaskState {
   final String shortMsg;
+
   TaskShortMessageState(String this.shortMsg);
+
   @override
   List<Object?> get props => [shortMsg];
 }
 
 class TasksLoadedState extends TaskState {
   final List<Task> tasks;
+
   TasksLoadedState(this.tasks);
+
   @override
   List<Object?> get props => [tasks];
 }
 
 class TaskDetailState extends TaskState {
   final Task task;
+
   TaskDetailState(this.task);
+
   @override
   List<Object?> get props => [task];
 }
@@ -43,6 +51,7 @@ class TaskDetailState extends TaskState {
 //-------   Task Turnpoints --------------------
 class TasksTurnpointsLoadingState extends TaskState {
   TasksTurnpointsLoadingState();
+
   @override
   List<Object?> get props => [];
 }
@@ -50,27 +59,33 @@ class TasksTurnpointsLoadingState extends TaskState {
 class TasksTurnpointsLoadedState extends TaskState {
   final Task task;
   final List<TaskTurnpoint> taskTurnpoints;
+
   TasksTurnpointsLoadedState(
       {required this.task, required this.taskTurnpoints});
+
   @override
   List<Object?> get props => [task, taskTurnpoints];
 }
 
 class TaskTurnpointErrorState extends TaskState {
   final String errorMsg;
+
   TaskTurnpointErrorState(String this.errorMsg);
+
   @override
   List<Object?> get props => [errorMsg];
 }
 
 class TaskModifiedState extends TaskState {
   TaskModifiedState();
+
   @override
   List<Object?> get props => [];
 }
 
 class TaskSavedState extends TaskState {
   TaskSavedState();
+
   @override
   List<Object?> get props => [];
 }
@@ -78,7 +93,19 @@ class TaskSavedState extends TaskState {
 // Turnpoint based on TaskTurnpoint
 class TurnpointFoundState extends TaskState {
   final Turnpoint turnpoint;
+
   TurnpointFoundState(this.turnpoint);
+
   @override
   List<Object?> get props => [turnpoint];
+}
+
+class ValidTaskState extends TaskState {
+  final bool validTask;
+  final String invalidTaskMsg;
+
+  ValidTaskState(this.validTask, { this.invalidTaskMsg = ""});
+
+  @override
+  List<Object?> get props => [validTask, invalidTaskMsg];
 }

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -11,7 +11,7 @@ description: A new Flutter application.
 # In iOS, build-name is used as CFBundleShortVersionString while build-number used as CFBundleVersion.
 # Read more about iOS versioning at
 # https://developer.apple.com/library/archive/documentation/General/Reference/InfoPlistKeyReference/Articles/CoreFoundationKeys.html
-version: 1.14.2+46
+version: 1.14.3+48
 
 environment:
   sdk: ">=3.4.3 <=3.6.0"


### PR DESCRIPTION
1. Added error checking to forbid saving task with only 2 turnpoints and  the start and end turnpoints are the same, or 0 or 1 turnpoints The condition of only 2 turnpoints with start and end the same caused crash on openmaps tile layout.
2. If Task Estimates tapped on main screen, return to it if no glider selected for task
3. Remove Flight Estimate button when task displayed and you switch regions.
4.Fixed and improved display of help text for Task Estimates and Glider Polar screen
5. Enable OK button on Glider list screen when screen displays a previously selected glider.
